### PR TITLE
SetLocale now works if Rails is reloading classes in development environ...

### DIFF
--- a/lib/set_locale/engine.rb
+++ b/lib/set_locale/engine.rb
@@ -4,7 +4,10 @@ module SetLocale
   class Engine < ::Rails::Engine
     config.after_initialize do |app|
       SetLocale.initialize
-      ApplicationController.send :include, SetLocale::ControllerHelpers
+
+      ActionDispatch::Callbacks.to_prepare do
+        ApplicationController.send :include, SetLocale::ControllerHelpers
+      end
     end
   end
 end


### PR DESCRIPTION
...ment (more accurately when classes aren’t cached)

This bug occured because SetLocale is including itself into ApplicationController during Application initialization but ApplicationController “forget’s” when reloading it’s class
One way would be to manually include SetLocale::ControllersHelpers into each Controller it is being used in, but we wanted to keep the zero-config approach and it’s not such a big overhead to include the SetLocale::ContollersHelper during each request in development
