### PR TITLE
allow specifying custom ApplicationController

### DIFF
--- a/lib/set_locale.rb
+++ b/lib/set_locale.rb
@@ -9,11 +9,15 @@ require "set_locale/engine"
 module SetLocale
 
   mattr_accessor :strategies
+  mattr_accessor :controller
 
   def self.initialize
     # Fall back to the default list of strategies unless
     # specified otherwise, in an initializer
     SetLocale.strategies ||= default_strategies
+
+    # Locale will be set before actions in this controller
+    SetLocale.controller ||= "ApplicationController"
   end
 
   # Find and return the first valid locale

--- a/lib/set_locale/controller_helpers.rb
+++ b/lib/set_locale/controller_helpers.rb
@@ -1,8 +1,8 @@
 module SetLocale
   module ControllerHelpers
 
-    def self.included(application_controller)
-      application_controller.before_action :set_locale
+    def self.included(controller)
+      controller.before_action :set_locale
     end
 
     def set_locale

--- a/lib/set_locale/engine.rb
+++ b/lib/set_locale/engine.rb
@@ -5,12 +5,12 @@ module SetLocale
     config.after_initialize do |app|
       SetLocale.initialize
 
-      ApplicationController.send :include, SetLocale::ControllerHelpers
+      SetLocale.controller.constantize.send :include, SetLocale::ControllerHelpers
 
       # Make sure SetLocale::ContollerHelpers gets included in ApplicationController
       # in case Rails would auto-reload ApplicationController during a request in development
       ActionDispatch::Reloader.to_prepare do
-        ApplicationController.send :include, SetLocale::ControllerHelpers
+        SetLocale.controller.constantize.send :include, SetLocale::ControllerHelpers
       end
     end
   end


### PR DESCRIPTION
Allows specifying a custom controller SetLocale will hook into. ApplicationController is still the default so SetLocale still works out-of the-box for most by just adding it to the Gemfile.

Useful when your Rails app have to serve different frontends with different ApplicationControllers, or if want to be able to fine-tune where exactly SetLocale should hook into.

We had to separate our JSON API from our ActiveAdmin-powered admin site, this change was inspired by the same pattern Devise is using with their Devise.parent_contoller config setting.
